### PR TITLE
Add InterfaceController_peerStats function

### DIFF
--- a/admin/commands.go
+++ b/admin/commands.go
@@ -93,6 +93,18 @@ func Memory(user *Admin) (memory int64, err error) {
 	return
 }
 
+// InterfaceController_peerStats returns a page of stats about direct peers
+func InterfaceController_peerStats(user *Admin, page int) (response map[string]interface{}, err error) {
+	args := make(map[string]interface{})
+	args["page"] = page
+
+	response, err = SendCmd(user, "InterfaceController_peerStats", args)
+	if err != nil {
+		return
+	}
+	return
+}
+
 // IpTunnel_listConnections returns a list of all current IP tunnels
 func IpTunnel_listConnections(user *Admin) (response map[string]interface{}, err error) {
 	response, err = SendCmd(user, "IpTunnel_listConnections", nil)


### PR DESCRIPTION
This returns a page of stats about the node's peers directly from the cjdns admin socket. It will be necessary in order to add a more accurate _peers_ function to [cjdcmd](https://github.com/inhies/cjdcmd). I will be submitting a pull request with that updated _peers_ function for cjdcmd very shortly.
